### PR TITLE
Removed ':' from property in MappingRawDataToInputData example since …

### DIFF
--- a/examples/_main/MappingRawDataToInputData_PersonIncome.json
+++ b/examples/_main/MappingRawDataToInputData_PersonIncome.json
@@ -3,7 +3,7 @@
     "sourceName": "income",
     "sourcePath": "/some/path/to/raw/data/",
     "targetInstanceVariable": "/InstanceVariable/71aec966-eb44-4a49-9bbf-0606563ca0cb",
-    "validFrom:": "1985-01-01T15:00:00.000Z",
+    "validFrom": "1985-01-01T15:00:00.000Z",
     "lastUpdatedDate": "1985-01-01T15:00:00.000Z",
     "lastUpdatedBy": "BNJ"
 }


### PR DESCRIPTION
…LDS is stricter with properties now.