### PR TITLE
About object

### DIFF
--- a/schemas/About.raml
+++ b/schemas/About.raml
@@ -1,0 +1,18 @@
+#%RAML 1.0 Library
+uses:
+  Link: ./annotation/Link.raml
+
+types:
+
+  # COMMENT:
+  # This object is not part of GSIM. This object is a GSIM extension (plugin)
+  # for use in Statistics Norway.
+  About:
+    description: Information about the model
+    displayName: About
+
+    properties:
+      version_0_4:
+        type: string
+        description: The version is in the attribute name
+        displayName: Current model version

--- a/schemas/About.raml
+++ b/schemas/About.raml
@@ -12,7 +12,8 @@ types:
     displayName: About
 
     properties:
-      version_0_4:
+      model_version:
         type: string
-        description: The version is in the attribute name
+        default: "0.5"
+        description: This version (0.5) added the About-object to the model
         displayName: Current model version

--- a/schemas/About.raml
+++ b/schemas/About.raml
@@ -15,5 +15,5 @@ types:
       model_version:
         type: string
         default: "0.5"
-        description: This version (0.5) added the About-object to the model
+        description: This version added the About-object to the model
         displayName: Current model version


### PR DESCRIPTION
Tenker vi kan få inn denne endringen jo før jo bedre.

Har gjort det enkelt. 

versjonsnummer legges i default-property, og hva som er hovedendringen i den versjonen legges i description.

Dermed kan dette objektet kalles uten at det må være data i modellen, 
f.eks. slik: <lds-server>/About?schema

