### PR TITLE
Business improvements 3

### DIFF
--- a/examples/_main/BusinessProcess_Example_1.json
+++ b/examples/_main/BusinessProcess_Example_1.json
@@ -16,7 +16,8 @@
   "validUntil": "2020-10-09T13:01:51.672Z",
   "isPlaceholderProcess": false,
   "processSteps": [
-    "/ProcessStep/1eef14a0-ff0c-4f43-9416-e9c871326c82"
+    "/ProcessStep/1eef14a0-ff0c-4f43-9416-e9c871326c82",
+    "/ProcessStep/1d39e9a7-494e-4257-951f-e494f45ae691"
   ],
   "previousBusinessProcess": "/BusinessProcess/dad379da-475c-44ac-98d7-56307c10a53c",
   "parentBusinessProcess": "/BusinessProcess/010bfa55-bd1c-4e7e-ae30-b8014c9fe623"

--- a/examples/_main/BusinessProcess_Example_1.json
+++ b/examples/_main/BusinessProcess_Example_1.json
@@ -14,6 +14,7 @@
   "lastUpdatedBy": "Test user",
   "validFrom": "2019-10-09T09:28:09.127Z",
   "validUntil": "2020-10-09T13:01:51.672Z",
+  "isPlaceholderProcess": false,
   "processSteps": [
     "/ProcessStep/1eef14a0-ff0c-4f43-9416-e9c871326c82"
   ],

--- a/examples/_main/BusinessProcess_Example_1.json
+++ b/examples/_main/BusinessProcess_Example_1.json
@@ -18,5 +18,6 @@
   "processSteps": [
     "/ProcessStep/1eef14a0-ff0c-4f43-9416-e9c871326c82"
   ],
-  "previousBusinessProcess": "/BusinessProcess/dad379da-475c-44ac-98d7-56307c10a53c"
+  "previousBusinessProcess": "/BusinessProcess/dad379da-475c-44ac-98d7-56307c10a53c",
+  "parentBusinessProcess": "/BusinessProcess/010bfa55-bd1c-4e7e-ae30-b8014c9fe623"
 }

--- a/examples/_main/BusinessProcess_Example_2.json
+++ b/examples/_main/BusinessProcess_Example_2.json
@@ -17,5 +17,6 @@
   "isPlaceholderProcess": false,
   "processSteps": [
     "/ProcessStep/ecd92c16-8119-4106-bc65-70dcc858d1cc"
-  ]
+  ],
+  "parentBusinessProcess": "/BusinessProcess/010bfa55-bd1c-4e7e-ae30-b8014c9fe623"
 }

--- a/examples/_main/BusinessProcess_Example_2.json
+++ b/examples/_main/BusinessProcess_Example_2.json
@@ -14,6 +14,7 @@
   "lastUpdatedBy": "Test user",
   "validFrom": "2019-10-09T10:36:32.121Z",
   "validUntil": "2020-10-10T11:24:55.842Z",
+  "isPlaceholderProcess": false,
   "processSteps": [
     "/ProcessStep/ecd92c16-8119-4106-bc65-70dcc858d1cc"
   ]

--- a/examples/_main/BusinessProcess_ParentProcess_Example.json
+++ b/examples/_main/BusinessProcess_ParentProcess_Example.json
@@ -1,0 +1,18 @@
+{
+  "id": "010bfa55-bd1c-4e7e-ae30-b8014c9fe623",
+  "name": [
+    {
+      "languageCode": "en",
+      "languageText": "Business Process Parent example"
+    }
+  ],
+  "createdDate": "2019-10-09T10:36:32.121Z",
+  "createdBy": "Test user",
+  "version": "1.0.0",
+  "versionValidFrom": "2019-10-26T11:24:55.842Z",
+  "lastUpdatedDate": "2019-10-26T11:24:55.842Z",
+  "lastUpdatedBy": "Test user",
+  "validFrom": "2019-10-09T10:36:32.121Z",
+  "validUntil": "2020-12-31T11:24:55.842Z",
+  "isPlaceholderProcess": true
+}

--- a/examples/_main/ProcessStep_Test.json
+++ b/examples/_main/ProcessStep_Test.json
@@ -3,7 +3,7 @@
   "name": [
     {
       "languageCode": "en",
-      "languageText": "Process Step example"
+      "languageText": "Process Step example 1"
     }
   ],
   "createdDate": "2019-09-23T12:50:15.456Z",

--- a/examples/_main/ProcessStep_Test2.json
+++ b/examples/_main/ProcessStep_Test2.json
@@ -1,0 +1,27 @@
+{
+  "id": "1d39e9a7-494e-4257-951f-e494f45ae691",
+  "name": [
+    {
+      "languageCode": "en",
+      "languageText": "Process Step example 2"
+    }
+  ],
+  "createdDate": "2019-10-25T12:50:15.456Z",
+  "createdBy": "Test user",
+  "version": "1.0.0",
+  "versionValidFrom": "2019-10-25T08:53:24.134Z",
+  "lastUpdatedDate": "2019-10-25T08:53:24.134Z",
+  "lastUpdatedBy": "Test user",
+  "validFrom": "2019-10-25T12:50:15.456Z",
+  "validUntil": "2020-10-25T08:53:24.134Z",
+  "isComprehensive": false,
+  "codeBlocks": [
+    {
+      "codeBlockIndex": 1,
+      "codeBlockTitle": "First doc",
+      "codeBlockType": "DOCUMENTATION",
+      "codeBlockValue": "%md\n# Process beskrivelse\nHer beskriver du hva det er dette process steget skal gjøre\n\n## Input\n- Lag en liste over de inputer som skal ingå i dette steget\n\n## Output\n- Lad en liste over de resultater som forventes av steget"
+    }
+  ],
+  "previousProcessStep": "/ProcessStep/1eef14a0-ff0c-4f43-9416-e9c871326c82"
+}

--- a/examples/_main/StatisticalProgramCycle_Example.json
+++ b/examples/_main/StatisticalProgramCycle_Example.json
@@ -15,7 +15,7 @@
   "validFrom": "2019-10-09T09:27:50.392Z",
   "validUntil": "2020-10-09T12:56:31.634Z",
   "businessProcesses": [
-    "/BusinessProcess/c99cf2fa-f8db-4f85-aae6-f46e6204c84f"
+    "/BusinessProcess/010bfa55-bd1c-4e7e-ae30-b8014c9fe623"
   ],
   "referencePeriodStart": "2019-10-08T22:00:00.000Z",
   "referencePeriodEnd": "2020-10-08T22:00:00.000Z"

--- a/examples/_main/TransformableInput_Example.json
+++ b/examples/_main/TransformableInput_Example.json
@@ -14,6 +14,5 @@
   "lastUpdatedBy": "Test user",
   "validFrom": "2019-10-14T13:00:35.974Z",
   "validUntil": "2020-10-14T13:00:35.974Z",
-  "inputType": "DATASET",
   "inputId": "/UnitDataSet/b9c10b86-5867-4270-b56e-ee7439fe381e"
 }

--- a/schemas/About.raml
+++ b/schemas/About.raml
@@ -13,6 +13,6 @@ types:
     properties:
       model_version:
         type: string
-        default: "0.7"
-        description: This version nested ProcessStepInstance inside the CodeBlocks attribute of ProcessStep
+        default: "0.8"
+        description: This version adds hierarchy to BusinessProcesses
         displayName: Current model version

--- a/schemas/BusinessProcess.raml
+++ b/schemas/BusinessProcess.raml
@@ -10,7 +10,7 @@ types:
     type: IdentifiableArtefact.IdentifiableArtefact
 
     properties:
-     isPlaceholderProcess:
+      isPlaceholderProcess:
         type: boolean
         default: false
         description: If true this is a placeholder-process (only a grouping of other businessprocesses in a hierarchical manner), but without link(s) to any ProcessSteps.

--- a/schemas/BusinessProcess.raml
+++ b/schemas/BusinessProcess.raml
@@ -10,7 +10,13 @@ types:
     type: IdentifiableArtefact.IdentifiableArtefact
 
     properties:
-      processSteps:
+     isPlaceholderProcess:
+        type: boolean
+        default: false
+        description: If true this is a placeholder-process (only a grouping of other businessprocesses in a hierarchical manner), but without link(s) to any ProcessSteps.
+        displayName: Is placeholder process
+    
+      processSteps?:
         type: string[]
         displayName: Process steps
         (Link.types): [ProcessStep]

--- a/schemas/BusinessProcess.raml
+++ b/schemas/BusinessProcess.raml
@@ -30,4 +30,9 @@ types:
         displayName: Previous Business Process
         (Link.types): [BusinessProcess]
 
+      parentBusinessProcess?:
+        type: string
+        displayName: Parent Business Process
+        (Link.types): [BusinessProcess]
+        
     example: !include ../examples/_main/BusinessProcess_Example_1.json

--- a/schemas/ProcessStep.raml
+++ b/schemas/ProcessStep.raml
@@ -36,4 +36,9 @@ types:
         displayName: Process control
         (Link.types): [ProcessControl]
 
+      previousProcessStep?: 
+        type: string
+        displayName: Previous process step
+        (Link.types): [ProcessStep]
+
     example: !include ../examples/_main/ProcessStep_Test.json

--- a/schemas/TransformableInput.raml
+++ b/schemas/TransformableInput.raml
@@ -11,13 +11,6 @@ types:
     type: [ IdentifiableArtefact.IdentifiableArtefact, ProcessInput.ProcessInput ]
 
     properties:
-      inputType:
-        type: string
-        description: Type of input resource (e.g. UnitDataSet, DimensionalDataSet, ...)
-        displayName: Input type
-        enum:
-          - DATASET
-
       inputId:
         type: string
         displayName: Input id


### PR DESCRIPTION
Åpnet for bruk av hierarki på BusinessProcess, samt bruk av previous-linker for å holde orden på rekkefølge på prosesser og prosessteg

- lagt til parent-, og placeholder-properties i BusinessProcess (etter modell fra LogicalRecords)
- lagt til previous-property i ProcessStep


Det begynner å bli temmelig komplisert nå med parent og previous linker, så vi trenger noen kjøreregler.  Her er hva jeg har konkludert med:

Strukturen og rekkefølge på eksemplene (/examples/_main/) er slik:

1 Statistical Program example
2 ../Statistical Program Cycle example (businessProcesses: 3)
3 ../../Business Process Parent example
4 ../../../Business Process dependency example (parent: 3, processSteps: 5)
5 ../../../../Process Step dependency example
6 ../../../Business Process example (parent: 3, previous: 4, processSteps: 7,8)
7 ../../../../Process Step example 1
8 ../../../../Process Step example 2 (previous: 7)

Regler:
* Linker fra "master" til "details" peker KUN på likestilte noder
-- dvs, hvis details har en parent/child struktur så pekes det kun på parent-noden
--      hvis details-noder er likestilt (søsken) så pekes det på alle disse
* parent-peker for å holde orden på nivå i hierarki
* previous-peker for å holde orden på sortering (uavhengig av hierarki eller ikke)
