### PR TITLE
versionValidUntil optional datatime property for IdentifiableArtefact

### DIFF
--- a/schemas/abstract/IdentifiableArtefact.raml
+++ b/schemas/abstract/IdentifiableArtefact.raml
@@ -57,8 +57,13 @@ types:
 
       versionValidFrom:
         type: datetime
-        description: The date on which the current version of the infomation object is effective or valid.
+        description: The date on which the current version of the information object is effective or valid.
         displayName: Version valid from
+
+      versionValidUntil?:
+        type: datetime
+        description: The date on which the current version of the information object is no longer effective or valid.
+        displayName: Version valid util
 
       versionRationale?:
         type: MultilingualText.MultilingualText[]


### PR DESCRIPTION
Klass Uttrekk (subsets) requires versionValidUntil property. It is a crusial element in use of the artefact versioning in the project.